### PR TITLE
eliminate YAMLLoadWarning

### DIFF
--- a/changesetmd.py
+++ b/changesetmd.py
@@ -178,7 +178,7 @@ class ChangesetMD():
         #at the end of this method to unlock the database or an error will forever leave it locked
         returnStatus = 0
         try:
-            serverState = yaml.load(requests.get(BASE_REPL_URL + "state.yaml").text)
+            serverState = yaml.safe_load(requests.get(BASE_REPL_URL + "state.yaml").text)
             lastServerSequence = serverState['sequence']
             print("got sequence")
             lastServerTimestamp = serverState['last_run']


### PR DESCRIPTION
warning was: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe.
solution seems to be to use safe_load, which works for this yaml file.