### PR TITLE
Debian 12 01

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ It is easiest if your OS user has access to this database. I just created a user
     createuser <username>
 
 
+Full Debian build instructions
+------------------------------
+
+    sudo apt install sudo screen locate git tar unzip wget bzip2 apache2 python3-psycopg2 python3-yaml libpq-dev postgresql postgresql-contrib postgis postgresql-15-postgis-3 postgresql-15-postgis-3-scripts net-tools curl python3-full gcc libpython3.11-dev libxml2-dev libxslt-dev
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+
+    sudo -u postgres -i
+    createuser youruseraccount
+    createdb -E UTF8 -O youruseraccount changesets
+
+    psql
+    \c changesets
+    CREATE EXTENSION postgis;
+    ALTER TABLE geometry_columns OWNER TO youruseraccount;
+    ALTER TABLE spatial_ref_sys OWNER TO youruseraccount;
+    \q
+    exit
+
+
 Execution
 ------------
 The first time you run it, you will need to include the -c | --create option to create the table:

--- a/README.md
+++ b/README.md
@@ -54,17 +54,19 @@ Execution
 ------------
 The first time you run it, you will need to include the -c | --create option to create the table:
 
-    python changesetmd.py -d <database> -c
+    python changesetmd.py -d <database> -c -g
+
+The `-g` | `--geometry` argument is optional and builds polygon geometries for changesets so that you can query which changesets were within which areas.
 
 The create function can be combined with the file option to immediately parse a file.
 
 To parse a dump file, use the -f | --file option.
 
-    python changesetmd.py -d <database> -f /tmp/changeset-latest.osm
+    python changesetmd.py -d <database> -g -f /tmp/discussions-latest.osm.bz2
 
 If no other arguments are given, it will access postgres using the default settings of the postgres client, typically connecting on the unix socket as the current OS user. Use the ```--help``` argument to see optional arguments for connecting to postgres.
 
-You can add the `-g` | `--geometry` option to build polygon geometries (the database also needs to be created with this option).
+Again, the `-g` | `--geometry` argument is optional.  Either of changeset-latest.osm.bz2 or discussions-latest.osm.bz2 or neither can be used to populate the database.
 
 Replication
 ------------

--- a/changesetmd.py
+++ b/changesetmd.py
@@ -233,7 +233,7 @@ class ChangesetMD:
         # at the end of this method to unlock the database or an error will forever leave it locked
         returnStatus = 0
         try:
-            serverState = yaml.load(requests.get(BASE_REPL_URL + "state.yaml").text)
+            serverState = yaml.full_load(requests.get(BASE_REPL_URL + "state.yaml").text)
             lastServerSequence = serverState["sequence"]
             print("got sequence")
             lastServerTimestamp = serverState["last_run"]


### PR DESCRIPTION
Two changes - one is that "yaml.load" seems to be now "yaml.full_load".
The other is to add an example build section for Debian 12, to take the guesswork out of builds on Debian-based systems.